### PR TITLE
Disabled links to other sessions and removed tools

### DIFF
--- a/01-glasswork/front-end-html.html
+++ b/01-glasswork/front-end-html.html
@@ -50,17 +50,13 @@
             <p>Wifi: username / password</p>
             <table class="tocTable" style="margin: 0 auto;">
               <tr>
-                <td>Install the Tools</td>
-                <td><a href="http://bit.ly/CnCTheTools" target="_blank">http://bit.ly/CnCTheTools</a></td>
-              </tr>
-              <tr>
                 <td>This presentation</td>
                 <td><a href="http://bit.ly/cnchtmlslide" target="_blank">http://bit.ly/cnchtmlslide</a></td>
               </tr>
-                <tr>
-                  <td>The worksheet</td>
-                  <td><a href="http://bit.ly/cnchtmlwork" target="_blank">http://bit.ly/cnchtmlwork</a></td>
-                </tr>
+              <tr>
+                <td>The worksheet</td>
+                <td><a href="http://bit.ly/cnchtmlwork" target="_blank">http://bit.ly/cnchtmlwork</a></td>
+              </tr>
             </table>
             <div class="row-line-tools" style="margin-top: -1.25em; margin-left: -0.65em;">
               <span class="row-line-tools"><a href="https://www.google.com/chrome/browser/desktop/index.html" target="_blank"><img src="/images/shared/chrome.png"/></a></span>
@@ -370,10 +366,6 @@
             <p>Wifi: username / password</p>
             <table class="tocTable" style="margin: 0 auto;">
               <tr>
-                <td>Install the Tools</td>
-                <td><a href="http://bit.ly/CnCTheTools" target="_blank">http://bit.ly/CnCTheTools</a></td>
-              </tr>
-              <tr>
                 <td>This presentation</td>
                 <td><a href="http://bit.ly/cnchtmlslide" target="_blank">http://bit.ly/cnchtmlslide</a></td>
               </tr>
@@ -517,10 +509,6 @@
                 <tr>
                   <td>The worksheet</td>
                   <td><a href="http://bit.ly/cnchtmlwork" target="_blank">http://bit.ly/cnchtmlwork</a></td>
-                </tr>
-                <tr>
-                  <td>Install the Tools</td>
-                  <td><a href="http://bit.ly/CnCTheTools" target="_blank">http://bit.ly/CnCTheTools</a></td>
                 </tr>
             </table>
             <div class="row-line-tools" style="margin-top: -1em; margin-left: -0.65em;">
@@ -708,10 +696,6 @@
             <p>Wifi: username / password</p>
             <table class="tocTable" style="margin: 0 auto;">
               <tr>
-                <td>Install the Tools</td>
-                <td><a href="http://bit.ly/CnCTheTools" target="_blank">http://bit.ly/CnCTheTools</a></td>
-              </tr>
-              <tr>
                 <td>This presentation</td>
                 <td><a href="http://bit.ly/cnchtmlslide" target="_blank">http://bit.ly/cnchtmlslide</a></td>
               </tr>
@@ -828,10 +812,6 @@
           <div class="fill-col" style="margin-top: ">
             <p>Wifi: username / password</p>
             <table class="tocTable" style="margin: 0 auto;">
-              <tr>
-                <td>Install the Tools</td>
-                <td><a href="http://bit.ly/CnCTheTools" target="_blank">http://bit.ly/CnCTheTools</a></td>
-              </tr>
               <tr>
                 <td>This presentation</td>
                 <td><a href="http://bit.ly/cnchtmlslide" target="_blank">http://bit.ly/cnchtmlslide</a></td>

--- a/index.html
+++ b/index.html
@@ -23,38 +23,38 @@
           </tr>
           <tr>
             <td style="text-align: left;">The Garnish: CSS</td>
-            <!-- <td class="disabled-link">slides</td>
-            <td class="disabled-link">worksheet</td> -->
-            <td><a href="02-garnish/css.html">slides</a></td>
-            <td><a href="http://bit.ly/cnccsswork" target="_blank">worksheet</a></td>
+            <td class="disabled-link">slides</td>
+            <td class="disabled-link">worksheet</td>
+            <!-- <td><a href="02-garnish/css.html">slides</a></td>
+            <td><a href="http://bit.ly/cnccsswork" target="_blank">worksheet</a></td> -->
           </tr>
-          <tr>
+          <!-- <tr>
             <td style="text-align: left;">The Rocks: Git</td>
-            <!-- <td class="disabled-link">slides</td>
-            <td class="disabled-link">worksheet</td> -->
+            <td class="disabled-link">slides</td>
+            <td class="disabled-link">worksheet</td>
             <td><a href="03-rocks/command-line-version-control.html">slides</a></td>
             <td><a href="http://bit.ly/cncgitwork">worksheet</a></td> 
-          </tr>
+          </tr> -->
           <tr>
             <td style="text-align: left;">The Liquor: JavaScript</td>
-            <!-- <td class="disabled-link">slides</td>
-            <td class="disabled-link">worksheet</td> -->
-            <td><a href="04-liquor/javascript-introduction.html">slides</a></td>
-            <td><a href="http://bit.ly/cncjavascriptwork">worksheet</a></td>
+            <td class="disabled-link">slides</td>
+            <td class="disabled-link">worksheet</td>
+            <!-- <td><a href="04-liquor/javascript-introduction.html">slides</a></td>
+            <td><a href="http://bit.ly/cncjavascriptwork">worksheet</a></td> -->
           </tr>
           <tr>
-            <td style="text-align: left;">The Mixers: Interactive</td>
-            <!-- <td class="disabled-link">slides</td>
-            <td class="disabled-link">worksheet</td> -->
-            <td><a href="05-mixers/interactive.html">slides</a></td>
-            <td><a href="http://bit.ly/cncinteractivework">worksheet</a></td>
-          </tr>
-          <tr>
-            <td style="text-align: left;">The Enjoy: Code Jam</td>
+            <td style="text-align: left;">Enjoy: Code Jam</td>
             <td class="disabled-link">slides</td>
             <td class="disabled-link">worksheet</td>
             <!-- <td><a href="06-enjoy/06-jun.html">slides</a></td>
             <td><a href="http://bit.ly/cncenjoywork">worksheet</a></td> -->
+          </tr>
+          <tr>
+            <td style="text-align: left;">The Mixers: API's</td>
+            <td class="disabled-link">slides</td>
+            <td class="disabled-link">worksheet</td>
+            <!-- <td><a href="05-mixers/interactive.html">slides</a></td>
+            <td><a href="http://bit.ly/cncinteractivework">worksheet</a></td> -->
           </tr>
         </table>
         <br>


### PR DESCRIPTION
Removed tools from break slides to reduce attendee confusion about how much prep is needed for the sessions. 

Disabled links and updated sessions for 2020.